### PR TITLE
Assignment 3.3: Lock .NET version to 7.0

### DIFF
--- a/3 Application Observability and Maintenance/3 Implementing Probes and Health Checks/health-probes/dockerfile
+++ b/3 Application Observability and Maintenance/3 Implementing Probes and Health Checks/health-probes/dockerfile
@@ -1,8 +1,8 @@
-FROM mcr.microsoft.com/dotnet/aspnet AS base
+FROM mcr.microsoft.com/dotnet/aspnet:7.0 AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM mcr.microsoft.com/dotnet/sdk AS build
+FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
 ENV ASPNETCORE_ENVIRONMENT=Production
 WORKDIR /src
 COPY health-probes.csproj .


### PR DESCRIPTION
After the release of .NET 8 assignment 3.3 is not working anymore. The Docker container won't start because of a different .NET version. By locking the Dockerfile to .NET 7 the applications starts again.