### PR TITLE
Fix: ERROR [4/6] RUN pip install -r requirements.txt

### DIFF
--- a/0 App/djackets_django/requirements.txt
+++ b/0 App/djackets_django/requirements.txt
@@ -24,7 +24,7 @@ pycparser==2.21
 PyJWT==2.3.0
 python3-openid==3.2.0
 pytz==2022.1
-PyYAML==6.0
+PyYAML==6.0.1
 requests==2.27.1
 requests-oauthlib==1.3.1
 six==1.16.0


### PR DESCRIPTION
Issue building djackets_django with lastest build on Windows 11
ERROR [4/6] RUN pip install -r requirements.txt 

issue is with: PyYAML==6.0 
From what i can see, it was reported:  6.0 was broken by Cython 3.0 release, they patched it in 6.0.1

This addressed the issue for me