### PR TITLE
fix/issue-51 : update image registry as k8s.gcr.io is deprecated

### DIFF
--- a/3 Application Observability and Maintenance/3 Implementing Probes and Health Checks/solution/busybox.pod.yml
+++ b/3 Application Observability and Maintenance/3 Implementing Probes and Health Checks/solution/busybox.pod.yml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
   - name: busybox-probes
-    image: k8s.gcr.io/busybox
+    image: registry.k8s.io/e2e-test-images/busybox:1.29-4
     resources:
       limits:
         memory: "64Mi" #64 MB


### PR DESCRIPTION
should fix https://github.com/nigelpoulton/ckad/issues/51